### PR TITLE
fix: replaced modal close event from onClick to onMouseDown

### DIFF
--- a/src/components/ui/alertDialog.tsx
+++ b/src/components/ui/alertDialog.tsx
@@ -72,7 +72,7 @@ export function AlertDialogContent({ children }: AlertDialogContentProps) {
       <Modal onClose={() => {}} show={true}>
         <div className="fixed inset-0 z-50 flex items-center justify-center">
           <div
-            onClick={(e) => e.stopPropagation()}
+            onMouseDown={(e) => e.stopPropagation()}
             className="relative grid w-full max-w-lg gap-4 border bg-background p-6 shadow-lg duration-200 sm:rounded-lg"
           >
             {children}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -76,7 +76,7 @@ export const DialogContent = forwardRef<HTMLDivElement, DialogContentProps>(
           <div className="fixed inset-0 z-50 flex items-center justify-center">
             <div
               ref={contentRef}
-              onClick={(e) => e.stopPropagation()}
+              onMouseDown={(e) => e.stopPropagation()}
               className={cn(
                 "relative grid w-full max-w-lg gap-4 border bg-background p-6 shadow-lg duration-200 sm:rounded-lg",
                 className,

--- a/src/components/ui/modal.tsx
+++ b/src/components/ui/modal.tsx
@@ -52,7 +52,7 @@ const ModalContent = forwardRef<HTMLDivElement, ModalContentProps>(
     return (
       <div
         ref={ref}
-        onClick={props.onClose}
+        onMouseDown={props.onClose}
         data-state="open"
         className={cn("fade-in-0 fixed inset-0 z-50 animate-in bg-black/80", className, classNative)}
         {...props}

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -132,7 +132,7 @@ export const PopoverContent = forwardRef<HTMLDivElement, PopoverContentProps>(
           data-popover-id={id}
           // @ts-expect-error
           ref={ref.setFloating}
-          onClick={(e) => e.stopPropagation()}
+          onMouseDown={(e) => e.stopPropagation()}
           style={floatingStyles}
           data-state={isOpen ? "open" : "closed"}
           data-side={side || "bottom"}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -374,7 +374,7 @@ export const SelectContent = forwardRef<HTMLDivElement, SelectContentProps>(
           data-select-id={id}
           // @ts-expect-error
           ref={ref.setFloating}
-          onClick={(e) => e.stopPropagation()}
+          onMouseDown={(e) => e.stopPropagation()}
           style={{
             ...floatingStyles,
             minWidth: `${triggerWidth}px`,

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -70,7 +70,7 @@ const SheetContent = forwardRef<ElementRef<typeof DialogContent>, SheetContentPr
         <Modal onClose={closeDialog} show={true}>
           <div
             ref={contentRef}
-            onClick={(e) => {
+            onMouseDown={(e) => {
               e.stopPropagation();
             }}
             {...props}


### PR DESCRIPTION
All component that use modals have a bug in close before a click outside the modal. If we click inside the modal, keep down, move the cursor outside the modal and relese, the modal will close.
To fix this I replace the event used from onClick to onMouseDown. I also replace the event stopPropagation in others component that use modals. 

![image](https://github.com/user-attachments/assets/9c12ad0e-8fd9-4955-9939-aa9511dcb5c1)
