### PR TITLE
doc:  complete astro installation documentation page

### DIFF
--- a/docs/astro-installation.md
+++ b/docs/astro-installation.md
@@ -213,6 +213,10 @@ export default {
 Create a CSS file (e.g., `styles.css`) and add the following base styles:
 
 ```css
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
 @layer base {
   :root {
     --background: 0 0% 100%;

--- a/src/components/InstallationForAstro.tsx
+++ b/src/components/InstallationForAstro.tsx
@@ -174,10 +174,6 @@ export default function InstallationForVite() {
             lang="ts"
           />
 
-          <h2 class="pt-4 font-semibold">
-            Update <code class="mx-2 rounded-sm bg-accent px-2">astro.config.mjs</code>
-          </h2>
-
           <p>
             Add the following overrides to your
             <code className="mx-2 rounded-sm bg-accent">package.json</code>:

--- a/src/components/InstallationForAstro.tsx
+++ b/src/components/InstallationForAstro.tsx
@@ -292,11 +292,15 @@ export default function InstallationForVite() {
 
           <p>
             Create a CSS file {"("}e.g.,
-            <code className="mx-2 rounded-sm bg-accent">styles.css</code>
-            {")"}and add the following base styles:
+            <code className="ml-1 rounded-sm bg-accent">styles.css</code>
+            {")"} and add the following base styles:
           </p>
           <HighlightCode
             codeString={`
+  @tailwind base;
+  @tailwind components;
+  @tailwind utilities;
+  
   @layer base {
     :root {
       --background: 0 0% 100%;

--- a/src/components/InstallationForAstro.tsx
+++ b/src/components/InstallationForAstro.tsx
@@ -1,89 +1,81 @@
-
 import { Step, StepContent, Steps, StepTitle } from "@ui/steps";
 
 import HighlightCode from "./CodePreview/HighlightCode";
 
-
 export default function InstallationForVite() {
+  return (
+    <Steps>
+      <Step>
+        <StepTitle label="1">Create project</StepTitle>
+        <StepContent>
+          <p>Run the following command to create a new Astro project:</p>
 
-    return (
-        <Steps>
-        <Step>
-          <StepTitle label="1">Create project</StepTitle>
-          <StepContent>
-            <p>Run the following command to create a new Astro project:</p>
-
-            <HighlightCode
-              codeString={`
+          <HighlightCode
+            codeString={`
   bun create astro@latest
               `}
-              lang="bash"
-            />
+            lang="bash"
+          />
 
-            <p>Select your preferred starter template when prompted.</p>
+          <p>Select your preferred starter template when prompted.</p>
+        </StepContent>
+      </Step>
+      <Step>
+        <StepTitle label="2">Add the Preact Integration</StepTitle>
+        <StepContent>
+          <p>To add Preact to your Astro project, execute:</p>
 
-          </StepContent>
-        </Step>
-        <Step>
-          <StepTitle label="2">Add the Preact Integration</StepTitle>
-          <StepContent>
-            <p>To add Preact to your Astro project, execute:</p>
-
-            <HighlightCode
-              codeString={
-                `
+          <HighlightCode
+            codeString={`
   bun run astro add preact
-                `
-              }
-              lang="bash"
-            />
+                `}
+            lang="bash"
+          />
 
-            <p>Type <code className="mx-2 rounded-sm bg-accent px-2">y</code> for all questions to confirm the installation.</p>
+          <p>
+            Type <code className="mx-2 rounded-sm bg-accent px-2">y</code> for all questions to confirm the
+            installation.
+          </p>
+        </StepContent>
+      </Step>
 
-          </StepContent>
-        </Step>
+      <Step>
+        <StepTitle label="3">Add Tailwind CSS 3</StepTitle>
+        <StepContent>
+          <p>
+            Follow the instructions in the{" "}
+            <a
+              class="font-medium underline"
+              href="https://docs.astro.build/en/guides/styling/#legacy-tailwind-3-support"
+            >
+              Astro Tailwind CSS Guide
+            </a>{" "}
+            to add Tailwind CSS.
+          </p>
 
-        <Step>
-          <StepTitle label="3">Add Tailwind CSS 3</StepTitle>
-          <StepContent>
-            {/* <Alert className="border-yellow-400">
-              <AlertCircle
-                className="h-4 w-4"
-                color="#facc15"
-              />
-              <AlertTitle>TailwindCSS version</AlertTitle>
-              <AlertDescription>
-                For now only supports TailwindCSS 3. In the future will support TailwindCSS 4.
-              </AlertDescription>
-            </Alert> */}
+          <p>Run the following command</p>
 
-            <p>
-              Follow the instructions in the{" "}
-              <a class='font-medium underline' href="https://astro.build/blog/tailwind-css">Astro Tailwind CSS Guide</a>
-              {" "}to add Tailwind CSS.
-            </p>
-
-            <p>Run the following command</p>
-
-            <HighlightCode
-              codeString={`
+          <HighlightCode
+            codeString={`
   bun add tailwindcss@3 @astrojs/tailwind
               `}
-              lang="bash"
-            />
+            lang="bash"
+          />
 
-            <h2 class='pt-4 font-semibold' >Update <code class='mx-2 rounded-sm bg-accent px-2'>astro.config.mjs</code></h2>
+          <h2 class="pt-4 font-semibold">
+            Update <code class="mx-2 rounded-sm bg-accent px-2">astro.config.mjs</code>
+          </h2>
 
-            <p>
-              Import the Tailwind integration in your 
-              <code className="mx-2 rounded-sm bg-accent px-2">astro.config.mjs</code>
-              file and add it to the
-              <code className="mx-2 rounded-sm bg-accent px-2">integrations</code>
-                array:
-              </p>
+          <p>
+            Import the Tailwind integration in your
+            <code className="mx-2 rounded-sm bg-accent px-2">astro.config.mjs</code>
+            file and add it to the
+            <code className="mx-2 rounded-sm bg-accent px-2">integrations</code>
+            array:
+          </p>
 
-            <HighlightCode
-              codeString={`
+          <HighlightCode
+            codeString={`
     // @ts-check
   import { defineConfig } from "astro/config";
   import preact from "@astrojs/preact";
@@ -94,16 +86,17 @@ export default function InstallationForVite() {
     integrations: [preact(), tailwind()],
   });
               `}
-              lang="ts"
-            />
+            lang="ts"
+          />
 
-            <h2 class='pt-4 font-semibold' >Configure Tailwind CSS</h2>
-            <p>
-              Add the following basic configuration to your<code className="mx-2 rounded-sm bg-accent px-2">tailwind.config.js</code>file:
-            </p>
+          <h2 class="pt-4 font-semibold">Configure Tailwind CSS</h2>
+          <p>
+            Add the following basic configuration to your
+            <code className="mx-2 rounded-sm bg-accent px-2">tailwind.config.js</code>file:
+          </p>
 
-            <HighlightCode
-              codeString={`
+          <HighlightCode
+            codeString={`
   /** @type {import('tailwindcss').Config} */
   export default {
     content: ["./src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}"],
@@ -113,19 +106,20 @@ export default function InstallationForVite() {
     plugins: [],
   };
               `}
-              lang="js"
-            />
-          </StepContent>
-        </Step>
+            lang="js"
+          />
+        </StepContent>
+      </Step>
 
-        <Step>
-          <StepTitle label="4">Update TypeScript Configuration</StepTitle>
-          <StepContent>
-            <p>
-             Modify your<code className="mx-2 rounded-sm bg-accent">tsconfig.json</code>to include the following settings:
-            </p>
-            <HighlightCode
-              codeString={`
+      <Step>
+        <StepTitle label="4">Update TypeScript Configuration</StepTitle>
+        <StepContent>
+          <p>
+            Modify your<code className="mx-2 rounded-sm bg-accent">tsconfig.json</code>to include the following
+            settings:
+          </p>
+          <HighlightCode
+            codeString={`
   {
     "compilerOptions": {
       "baseUrl": "./",
@@ -136,25 +130,26 @@ export default function InstallationForVite() {
     }
   }
                 `}
-              lang="json"
-            />
-            <p>Install the Node.js types as a development dependency:</p>
-            <HighlightCode
-              codeString={`
+            lang="json"
+          />
+          <p>Install the Node.js types as a development dependency:</p>
+          <HighlightCode
+            codeString={`
   bun add -D @types/node
               `}
-              lang='bash'
-            />
+            lang="bash"
+          />
 
-            <h2 class='pt-4 font-semibold' >Update <code class='mx-2 rounded-sm bg-accent px-2'>astro.config.mjs</code></h2>
-            
-            <p>
-              Make the following changes to your
-              <code className="mx-2 rounded-sm bg-accent">astro.config.mjs</code>
-              :
-            </p>
-            <HighlightCode
-                codeString={`
+          <h2 class="pt-4 font-semibold">
+            Update <code class="mx-2 rounded-sm bg-accent px-2">astro.config.mjs</code>
+          </h2>
+
+          <p>
+            Make the following changes to your
+            <code className="mx-2 rounded-sm bg-accent">astro.config.mjs</code>:
+          </p>
+          <HighlightCode
+            codeString={`
   // @ts-check
   import { defineConfig } from "astro/config";
   import preact from "@astrojs/preact";
@@ -176,18 +171,19 @@ export default function InstallationForVite() {
     },
   });
                 `}
-                lang='bash'
-              />
-              
-              <h2 class='pt-4 font-semibold' >Update <code class='mx-2 rounded-sm bg-accent px-2'>astro.config.mjs</code></h2>
-            
-            <p>
-              Add the following overrides to your
-              <code className="mx-2 rounded-sm bg-accent">package.json</code>
-              :
-            </p>
-            <HighlightCode
-                codeString={`
+            lang="ts"
+          />
+
+          <h2 class="pt-4 font-semibold">
+            Update <code class="mx-2 rounded-sm bg-accent px-2">astro.config.mjs</code>
+          </h2>
+
+          <p>
+            Add the following overrides to your
+            <code className="mx-2 rounded-sm bg-accent">package.json</code>:
+          </p>
+          <HighlightCode
+            codeString={`
   {
     "overrides": {
       "react": "npm:@preact/compat@latest",
@@ -195,32 +191,35 @@ export default function InstallationForVite() {
     }
   }
                   `}
-                  lang="json"
-              />
-          </StepContent>
-        </Step>
+            lang="json"
+          />
+        </StepContent>
+      </Step>
 
-        <Step>
-          <StepTitle label="5">Install Additional Packages</StepTitle>
-          <StepContent>
-            <p>Run the following command to install additional dependencies:</p>
+      <Step>
+        <StepTitle label="5">Install Additional Packages</StepTitle>
+        <StepContent>
+          <p>Run the following command to install additional dependencies:</p>
 
-            <HighlightCode
-              codeString={`
+          <HighlightCode
+            codeString={`
   bun add class-variance-authority clsx cmdk date-fns dayjs embla-carousel-react input-otp lucide-preact react-day-picker react-hot-toast recharts tailwind-merge tailwindcss-animate vaul @floating-ui/react-dom
               `}
-              lang="bash"
-            />
-            </StepContent>
-        </Step>
+            lang="bash"
+          />
+        </StepContent>
+      </Step>
 
-        <Step>
-          <StepTitle label="6">Update Tailwind CSS Configuration</StepTitle>
-          <StepContent>
-            <p>Modify your<code className="mx-2 rounded-sm bg-accent">tailwind.config.js</code>to include dark mode and extend the theme:</p>
+      <Step>
+        <StepTitle label="6">Update Tailwind CSS Configuration</StepTitle>
+        <StepContent>
+          <p>
+            Modify your<code className="mx-2 rounded-sm bg-accent">tailwind.config.js</code>to include dark mode and
+            extend the theme:
+          </p>
 
-            <HighlightCode
-              codeString={`
+          <HighlightCode
+            codeString={`
   /** @type {import('tailwindcss').Config} */
   export default {
     content: ["./src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}"],
@@ -290,18 +289,18 @@ export default function InstallationForVite() {
     plugins: [require("tailwindcss-animate")],
   };
                 `}
-              lang="bash"
-            />
+            lang="js"
+          />
 
-            <h2 class='pt-4 font-semibold' >Add Base Styles</h2>
-            
-            <p>
-              Create a CSS file {"("}e.g.,
-              <code className="mx-2 rounded-sm bg-accent">styles.css</code>
-              {")"}and add the following base styles:
-            </p>
-            <HighlightCode
-                codeString={`
+          <h2 class="pt-4 font-semibold">Add Base Styles</h2>
+
+          <p>
+            Create a CSS file {"("}e.g.,
+            <code className="mx-2 rounded-sm bg-accent">styles.css</code>
+            {")"}and add the following base styles:
+          </p>
+          <HighlightCode
+            codeString={`
   @layer base {
     :root {
       --background: 0 0% 100%;
@@ -367,24 +366,23 @@ export default function InstallationForVite() {
     @apply bg-background text-foreground;
   }
                 `}
-                lang='css'
-            />
-            </StepContent>
-        </Step>
-        <Step>
-          <StepTitle label="7">Copy UI Components</StepTitle>
-          <StepContent>
-            <p>To copy the UI components, run the following command:</p>
+            lang="css"
+          />
+        </StepContent>
+      </Step>
+      <Step>
+        <StepTitle label="7">Copy UI Components</StepTitle>
+        <StepContent>
+          <p>To copy the UI components, run the following command:</p>
 
-            <HighlightCode
-              codeString={`
+          <HighlightCode
+            codeString={`
   bunx degit https://github.com/LiasCode/shadcn-preact/src/components/ui ./src/components/ui
               `}
-              lang="bash"
-            />
-            </StepContent>
-        </Step>
-      </Steps>
-    )
+            lang="bash"
+          />
+        </StepContent>
+      </Step>
+    </Steps>
+  );
 }
-

--- a/src/components/InstallationForAstro.tsx
+++ b/src/components/InstallationForAstro.tsx
@@ -1,0 +1,390 @@
+
+import { Step, StepContent, Steps, StepTitle } from "@ui/steps";
+
+import HighlightCode from "./CodePreview/HighlightCode";
+
+
+export default function InstallationForVite() {
+
+    return (
+        <Steps>
+        <Step>
+          <StepTitle label="1">Create project</StepTitle>
+          <StepContent>
+            <p>Run the following command to create a new Astro project:</p>
+
+            <HighlightCode
+              codeString={`
+  bun create astro@latest
+              `}
+              lang="bash"
+            />
+
+            <p>Select your preferred starter template when prompted.</p>
+
+          </StepContent>
+        </Step>
+        <Step>
+          <StepTitle label="2">Add the Preact Integration</StepTitle>
+          <StepContent>
+            <p>To add Preact to your Astro project, execute:</p>
+
+            <HighlightCode
+              codeString={
+                `
+  bun run astro add preact
+                `
+              }
+              lang="bash"
+            />
+
+            <p>Type <code className="mx-2 rounded-sm bg-accent px-2">y</code> for all questions to confirm the installation.</p>
+
+          </StepContent>
+        </Step>
+
+        <Step>
+          <StepTitle label="3">Add Tailwind CSS 3</StepTitle>
+          <StepContent>
+            {/* <Alert className="border-yellow-400">
+              <AlertCircle
+                className="h-4 w-4"
+                color="#facc15"
+              />
+              <AlertTitle>TailwindCSS version</AlertTitle>
+              <AlertDescription>
+                For now only supports TailwindCSS 3. In the future will support TailwindCSS 4.
+              </AlertDescription>
+            </Alert> */}
+
+            <p>
+              Follow the instructions in the{" "}
+              <a class='font-medium underline' href="https://astro.build/blog/tailwind-css">Astro Tailwind CSS Guide</a>
+              {" "}to add Tailwind CSS.
+            </p>
+
+            <p>Run the following command</p>
+
+            <HighlightCode
+              codeString={`
+  bun add tailwindcss@3 @astrojs/tailwind
+              `}
+              lang="bash"
+            />
+
+            <h2 class='pt-4 font-semibold' >Update <code class='mx-2 rounded-sm bg-accent px-2'>astro.config.mjs</code></h2>
+
+            <p>
+              Import the Tailwind integration in your 
+              <code className="mx-2 rounded-sm bg-accent px-2">astro.config.mjs</code>
+              file and add it to the
+              <code className="mx-2 rounded-sm bg-accent px-2">integrations</code>
+                array:
+              </p>
+
+            <HighlightCode
+              codeString={`
+    // @ts-check
+  import { defineConfig } from "astro/config";
+  import preact from "@astrojs/preact";
+  import tailwind from "@astrojs/tailwind";
+
+  // https://astro.build/config
+  export default defineConfig({
+    integrations: [preact(), tailwind()],
+  });
+              `}
+              lang="ts"
+            />
+
+            <h2 class='pt-4 font-semibold' >Configure Tailwind CSS</h2>
+            <p>
+              Add the following basic configuration to your<code className="mx-2 rounded-sm bg-accent px-2">tailwind.config.js</code>file:
+            </p>
+
+            <HighlightCode
+              codeString={`
+  /** @type {import('tailwindcss').Config} */
+  export default {
+    content: ["./src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}"],
+    theme: {
+      extend: {},
+    },
+    plugins: [],
+  };
+              `}
+              lang="js"
+            />
+          </StepContent>
+        </Step>
+
+        <Step>
+          <StepTitle label="4">Update TypeScript Configuration</StepTitle>
+          <StepContent>
+            <p>
+             Modify your<code className="mx-2 rounded-sm bg-accent">tsconfig.json</code>to include the following settings:
+            </p>
+            <HighlightCode
+              codeString={`
+  {
+    "compilerOptions": {
+      "baseUrl": "./",
+      "paths": {
+        "@/*": ["./src/*"],
+        "@ui/*": ["./src/components/ui/*"]
+      }
+    }
+  }
+                `}
+              lang="json"
+            />
+            <p>Install the Node.js types as a development dependency:</p>
+            <HighlightCode
+              codeString={`
+  bun add -D @types/node
+              `}
+              lang='bash'
+            />
+
+            <h2 class='pt-4 font-semibold' >Update <code class='mx-2 rounded-sm bg-accent px-2'>astro.config.mjs</code></h2>
+            
+            <p>
+              Make the following changes to your
+              <code className="mx-2 rounded-sm bg-accent">astro.config.mjs</code>
+              :
+            </p>
+            <HighlightCode
+                codeString={`
+  // @ts-check
+  import { defineConfig } from "astro/config";
+  import preact from "@astrojs/preact";
+  import tailwind from "@astrojs/tailwind";
+  import { resolve } from "path";
+
+  const __dirname = import.meta.dirname;
+
+  // https://astro.build/config
+  export default defineConfig({
+    integrations: [preact({ compat: true }), tailwind()],
+    vite: {
+      resolve: {
+        alias: {
+          "@ui": resolve(resolve(__dirname), "./src/components/ui/"),
+          "@": resolve(resolve(__dirname), "./src/"),
+        },
+      },
+    },
+  });
+                `}
+                lang='bash'
+              />
+              
+              <h2 class='pt-4 font-semibold' >Update <code class='mx-2 rounded-sm bg-accent px-2'>astro.config.mjs</code></h2>
+            
+            <p>
+              Add the following overrides to your
+              <code className="mx-2 rounded-sm bg-accent">package.json</code>
+              :
+            </p>
+            <HighlightCode
+                codeString={`
+  {
+    "overrides": {
+      "react": "npm:@preact/compat@latest",
+      "react-dom": "npm:@preact/compat@latest"
+    }
+  }
+                  `}
+                  lang="json"
+              />
+          </StepContent>
+        </Step>
+
+        <Step>
+          <StepTitle label="5">Install Additional Packages</StepTitle>
+          <StepContent>
+            <p>Run the following command to install additional dependencies:</p>
+
+            <HighlightCode
+              codeString={`
+  bun add class-variance-authority clsx cmdk date-fns dayjs embla-carousel-react input-otp lucide-preact react-day-picker react-hot-toast recharts tailwind-merge tailwindcss-animate vaul @floating-ui/react-dom
+              `}
+              lang="bash"
+            />
+            </StepContent>
+        </Step>
+
+        <Step>
+          <StepTitle label="6">Update Tailwind CSS Configuration</StepTitle>
+          <StepContent>
+            <p>Modify your<code className="mx-2 rounded-sm bg-accent">tailwind.config.js</code>to include dark mode and extend the theme:</p>
+
+            <HighlightCode
+              codeString={`
+  /** @type {import('tailwindcss').Config} */
+  export default {
+    content: ["./src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}"],
+    darkMode: ["class"],
+    theme: {
+      extend: {
+        colors: {
+          background: "hsl(var(--background))",
+          foreground: "hsl(var(--foreground))",
+          card: {
+            DEFAULT: "hsl(var(--card))",
+            foreground: "hsl(var(--card-foreground))",
+          },
+          popover: {
+            DEFAULT: "hsl(var(--popover))",
+            foreground: "hsl(var(--popover-foreground))",
+          },
+          primary: {
+            DEFAULT: "hsl(var(--primary))",
+            foreground: "hsl(var(--primary-foreground))",
+          },
+          secondary: {
+            DEFAULT: "hsl(var(--secondary))",
+            foreground: "hsl(var(--secondary-foreground))",
+          },
+          muted: {
+            DEFAULT: "hsl(var(--muted))",
+            foreground: "hsl(var(--muted-foreground))",
+          },
+          accent: {
+            DEFAULT: "hsl(var(--accent))",
+            foreground: "hsl(var(--accent-foreground))",
+          },
+          destructive: {
+            DEFAULT: "hsl(var(--destructive))",
+            foreground: "hsl(var(--destructive-foreground))",
+          },
+          border: "hsl(var(--border))",
+          input: "hsl(var(--input))",
+          ring: "hsl(var(--ring))",
+          chart: {
+            1: "hsl(var(--chart-1))",
+            2: "hsl(var(--chart-2))",
+            3: "hsl(var(--chart-3))",
+            4: "hsl(var(--chart-4))",
+            5: "hsl(var(--chart-5))",
+          },
+        },
+        borderRadius: {
+          "2xl": "calc(var(--radius) + 4px)",
+          "xl": "calc(var(--radius) + 2px)",
+          "lg": "var(--radius)",
+          "md": "calc(var(--radius) - 2px)",
+          "sm": "calc(var(--radius) - 4px)",
+        },
+        keyframes: {
+          "caret-blink": {
+            "0%,70%,100%": { opacity: "1" },
+            "20%,50%": { opacity: "0" },
+          },
+        },
+        animation: {
+          "caret-blink": "caret-blink 1.25s ease-out infinite",
+        },
+      },
+    },
+    plugins: [require("tailwindcss-animate")],
+  };
+                `}
+              lang="bash"
+            />
+
+            <h2 class='pt-4 font-semibold' >Add Base Styles</h2>
+            
+            <p>
+              Create a CSS file {"("}e.g.,
+              <code className="mx-2 rounded-sm bg-accent">styles.css</code>
+              {")"}and add the following base styles:
+            </p>
+            <HighlightCode
+                codeString={`
+  @layer base {
+    :root {
+      --background: 0 0% 100%;
+      --foreground: 240 10% 3.9%;
+      --card: 0 0% 100%;
+      --card-foreground: 240 10% 3.9%;
+      --popover: 0 0% 100%;
+      --popover-foreground: 240 10% 3.9%;
+      --primary: 240 5.9% 10%;
+      --primary-foreground: 0 0% 98%;
+      --secondary: 240 4.8% 95.9%;
+      --secondary-foreground: 240 5.9% 10%;
+      --muted: 240 4.8% 95.9%;
+      --muted-foreground: 240 3.8% 46.1%;
+      --accent: 240 4.8% 95.9%;
+      --accent-foreground: 240 5.9% 10%;
+      --destructive: 0 84.2% 60.2%;
+      --destructive-foreground: 0 0% 98%;
+      --border: 240 5.9% 90%;
+      --input: 240 5.9% 90%;
+      --ring: 240 5.9% 10%;
+      --radius: 0.5rem;
+      --chart-1: 12 76% 61%;
+      --chart-2: 173 58% 39%;
+      --chart-3: 197 37% 24%;
+      --chart-4: 43 74% 66%;
+      --chart-5: 27 87% 67%;
+    }
+
+    .dark {
+      --background: 240 10% 3.9%;
+      --foreground: 0 0% 98%;
+      --card: 240 10% 3.9%;
+      --card-foreground: 0 0% 98%;
+      --popover: 240 10% 3.9%;
+      --popover-foreground: 0 0% 98%;
+      --primary: 0 0% 98%;
+      --primary-foreground: 240 5.9% 10%;
+      --secondary: 240 3.7% 15.9%;
+      --secondary-foreground: 0 0% 98%;
+      --muted: 240 3.7% 15.9%;
+      --muted-foreground: 240 5% 64.9%;
+      --accent: 240 3.7% 15.9%;
+      --accent-foreground: 0 0% 98%;
+      --destructive: 0 62.8% 30.6%;
+      --destructive-foreground: 0 0% 98%;
+      --border: 240 3.7% 15.9%;
+      --input: 240 3.7% 15.9%;
+      --ring: 240 4.9% 83.9%;
+      --chart-1: 220 70% 50%;
+      --chart-2: 160 60% 45%;
+      --chart-3: 30 80% 55%;
+      --chart-4: 280 65% 60%;
+      --chart-5: 340 75% 55%;
+    }
+  }
+
+  * {
+    @apply border-border;
+  }
+
+  body {
+    @apply bg-background text-foreground;
+  }
+                `}
+                lang='css'
+            />
+            </StepContent>
+        </Step>
+        <Step>
+          <StepTitle label="7">Copy UI Components</StepTitle>
+          <StepContent>
+            <p>To copy the UI components, run the following command:</p>
+
+            <HighlightCode
+              codeString={`
+  bunx degit https://github.com/LiasCode/shadcn-preact/src/components/ui ./src/components/ui
+              `}
+              lang="bash"
+            />
+            </StepContent>
+        </Step>
+      </Steps>
+    )
+}
+

--- a/src/routes/Docs/InstallationAstro.tsx
+++ b/src/routes/Docs/InstallationAstro.tsx
@@ -1,5 +1,4 @@
 import { DocsLayout } from "@/components/Layout/DocsLayout";
-import { Alert, AlertDescription, AlertTitle } from "@ui/alert";
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -8,11 +7,15 @@ import {
   BreadcrumbPage,
   BreadcrumbSeparator,
 } from "@ui/breadcrumb";
-import { Button, buttonVariants } from "@ui/button";
+import { Button } from "@ui/button";
 import { Pagination, PaginationContent, PaginationItem } from "@ui/pagination";
-import { cn } from "@ui/share/cn";
-import { AlertCircle, ChevronLeft, ChevronRight, ExternalLink } from "lucide-preact";
+
+import { ChevronLeft, ChevronRight } from "lucide-preact";
 import { AppRoutes } from "../AppRoutes";
+import { lazy, Suspense } from "preact/compat";
+import { LoadingSpinner } from "@/components/LoadingSpinner";
+
+const InstallationGuideAstro = lazy(() => import("../../components/InstallationForAstro"));
 
 export default function InstallationAstroPage() {
   return (
@@ -42,30 +45,19 @@ export default function InstallationAstroPage() {
           </BreadcrumbList>
         </Breadcrumb>
       }
-      title="Astro Installation"
-      description="How to install dependencies and structure your app with Astro."
+      title="Setting Up an Astro Project with Preact and Tailwind CSS"
+      description="This guide will walk you through creating an Astro project with Preact integration and Tailwind CSS for styling."
     >
-      <Alert className="border-yellow-400">
-        <AlertCircle
-          className="h-4 w-4"
-          color="#facc15"
-        />
-        <AlertTitle>Page under construction</AlertTitle>
-        <AlertDescription>Astro guide page is on work in progress.</AlertDescription>
-      </Alert>
-
-      <div className="my-4 flex w-full flex-col">
-        <a
-          className={cn(buttonVariants({ variant: "secondary", size: "sm" }), "w-fit font-normal")}
-          target="_blank"
-          rel="noreferrer"
-          href="https://github.com/LiasCode/shadcn-preact/blob/main/docs/astro-installation.md"
-        >
-          See this guide
-          <ExternalLink />
-        </a>
-      </div>
-
+      <Suspense
+        fallback={
+          <div className="flex w-full flex-col items-center justify-center">
+            <LoadingSpinner />
+          </div>
+        }
+      >
+        <InstallationGuideAstro />
+      </Suspense>
+      
       <Pagination className="mt-10">
         <PaginationContent className="flex w-full flex-row justify-between">
           <PaginationItem>

--- a/src/routes/Docs/InstallationAstro.tsx
+++ b/src/routes/Docs/InstallationAstro.tsx
@@ -10,10 +10,10 @@ import {
 import { Button } from "@ui/button";
 import { Pagination, PaginationContent, PaginationItem } from "@ui/pagination";
 
-import { ChevronLeft, ChevronRight } from "lucide-preact";
-import { AppRoutes } from "../AppRoutes";
-import { lazy, Suspense } from "preact/compat";
 import { LoadingSpinner } from "@/components/LoadingSpinner";
+import { ChevronLeft, ChevronRight } from "lucide-preact";
+import { lazy, Suspense } from "preact/compat";
+import { AppRoutes } from "../AppRoutes";
 
 const InstallationGuideAstro = lazy(() => import("../../components/InstallationForAstro"));
 
@@ -45,8 +45,8 @@ export default function InstallationAstroPage() {
           </BreadcrumbList>
         </Breadcrumb>
       }
-      title="Setting Up an Astro Project with Preact and Tailwind CSS"
-      description="This guide will walk you through creating an Astro project with Preact integration and Tailwind CSS for styling."
+      title="Astro Installation"
+      description="How to install dependencies and structure your app with astro."
     >
       <Suspense
         fallback={
@@ -57,7 +57,7 @@ export default function InstallationAstroPage() {
       >
         <InstallationGuideAstro />
       </Suspense>
-      
+
       <Pagination className="mt-10">
         <PaginationContent className="flex w-full flex-row justify-between">
           <PaginationItem>


### PR DESCRIPTION
Complete Astro Installation documentation page based in [astro-installation.md](https://github.com/LiasCode/shadcn-preact/blob/main/docs/astro-installation.md) and [astro installation documentaton page](https://shadcn-preact.onrender.com/docs/installation/vite)

![image](https://github.com/user-attachments/assets/14d22c57-e22c-425e-b097-39cc5789e6a4)
